### PR TITLE
feat: split filename and path when using find_files

### DIFF
--- a/lua/better-telescope-builtins/files.lua
+++ b/lua/better-telescope-builtins/files.lua
@@ -41,7 +41,7 @@ local find_files = function(opts)
   opts = opts or {}
 
   if opts.find_command == nil then
-    opts.find_command = { 'fd', '--type', 'file', '--color', 'never', '--hidden', '--exlucde', '.git' }
+    opts.find_command = { 'fd', '--type', 'file', '--color', 'never', '--hidden', '--exclude', '.git' }
   end
 
   if opts.find_command[1] ~= 'fd' then

--- a/lua/better-telescope-builtins/files.lua
+++ b/lua/better-telescope-builtins/files.lua
@@ -1,0 +1,79 @@
+local pickers = require 'telescope.pickers'
+local finders = require 'telescope.finders'
+local conf = require('telescope.config').values
+local notify = require('telescope.utils').notify
+local make_entry = require 'telescope.make_entry'
+local entry_display = require 'telescope.pickers.entry_display'
+local utils = require('better-telescope-builtins.utils')
+local strings = require('plenary.strings')
+
+local file_entry_maker = function(opts)
+  opts = opts or {}
+  local default_entry_maker = make_entry.gen_from_file(opts)
+  local iconwidth = (not opts.disable_devicons) and 1 or 0
+  local displayer = entry_display.create({
+    separator = ' ',
+    items = {
+      { width = iconwidth, },
+      { width = nil, },
+      { remaining = true, },
+    },
+  })
+  local my_entry_maker = function(line)
+    local entry = default_entry_maker(line)
+    entry.display = function(e)
+      local entry_width = utils.get_entry_width()
+      local icon, icon_hl = utils.devicon_for(e.value, opts)
+      local max_path_len = entry_width - (icon and 2 or 0)
+      local filename, parents_str = utils.filename_and_shorten_parents(e.value, max_path_len)
+      return displayer {
+        { icon,                                                               icon_hl },
+        { filename },
+        { strings.align_str(parents_str, max_path_len - #filename - 1, true), 'Comment' }
+      }
+    end
+    return entry
+  end
+  return my_entry_maker
+end
+
+local find_files = function(opts)
+  opts = opts or {}
+
+  if opts.find_command == nil then
+    opts.find_command = { 'fd', '--type', 'file', '--color', 'never', '--hidden' }
+  end
+
+  if opts.find_command[1] ~= 'fd' then
+    notify('find_files', {
+      msg = 'Please use fd in find_command',
+      level = 'ERROR',
+    })
+    return
+  end
+
+  if 1 ~= vim.fn.executable 'fd' then
+    notify('find_files', {
+      msg = 'You need to install fd',
+      level = 'ERROR',
+    })
+    return
+  end
+
+  if opts.cwd then
+    opts.cwd = vim.fn.expand(opts.cwd)
+  end
+
+  opts.entry_maker = opts.entry_maker or file_entry_maker(opts)
+
+  pickers
+      .new(opts, {
+        prompt_title = 'Find Files',
+        finder = finders.new_oneshot_job(opts.find_command, opts),
+        previewer = conf.file_previewer(opts),
+        sorter = conf.file_sorter(opts),
+      })
+      :find()
+end
+
+return { find_files = find_files }

--- a/lua/better-telescope-builtins/files.lua
+++ b/lua/better-telescope-builtins/files.lua
@@ -41,7 +41,7 @@ local find_files = function(opts)
   opts = opts or {}
 
   if opts.find_command == nil then
-    opts.find_command = { 'fd', '--type', 'file', '--color', 'never', '--hidden' }
+    opts.find_command = { 'fd', '--type', 'file', '--color', 'never', '--hidden', '--exlucde', '.git' }
   end
 
   if opts.find_command[1] ~= 'fd' then

--- a/lua/better-telescope-builtins/init.lua
+++ b/lua/better-telescope-builtins/init.lua
@@ -1,0 +1,3 @@
+return {
+  find_files = require('better-telescope-builtins.files').find_files
+}

--- a/lua/better-telescope-builtins/utils.lua
+++ b/lua/better-telescope-builtins/utils.lua
@@ -1,0 +1,98 @@
+local get_status = require('telescope.state').get_status
+local path_tail = require('telescope.utils').path_tail
+local file_extension = require('telescope.utils').file_extension
+
+local utils = {}
+
+utils.get_entry_width = function()
+  local status = get_status(vim.api.nvim_get_current_buf())
+  return vim.api.nvim_win_get_width(status.results_win) - status.picker.selection_caret:len()
+end
+
+local reverse = function(list)
+  local result = {}
+  for i = #list, 1, -1 do
+    result[#result + 1] = list[i]
+  end
+  return result
+end
+
+local shorten_path = function(dirs, max_len)
+  if #dirs == 0 then
+    return './'
+  end
+  if #dirs == 1 then
+    return dirs[1]
+  end
+  local lefts = { dirs[1] }
+  local rights = { dirs[#dirs] }
+  local left_end = 1
+  local right_start = #dirs
+  local left_len = #lefts[1]
+  local right_len = #rights[1]
+  while left_end + 1 < right_start do
+    if #lefts < #rights then
+      if left_len + right_len + #dirs[left_end + 1] + #lefts + #rights > max_len then
+        break
+      end
+      left_len = left_len + #dirs[left_end + 1]
+      table.insert(lefts, dirs[left_end + 1])
+      left_end = left_end + 1
+    else
+      if left_len + right_len + #dirs[right_start - 1] + #lefts + #rights > max_len then
+        break
+      end
+      right_len = right_len + #dirs[right_start - 1]
+      table.insert(rights, dirs[right_start - 1])
+      right_start = right_start - 1
+    end
+  end
+  rights = reverse(rights)
+  local parts = {}
+  for _, v in ipairs(lefts) do
+    table.insert(parts, v)
+  end
+  if #lefts + #rights < #dirs then
+    table.insert(parts, '...')
+  end
+  for _, v in ipairs(rights) do
+    table.insert(parts, v)
+  end
+  return table.concat(parts, '/')
+end
+
+utils.filename_and_shorten_parents = function(path, max_len)
+  local parents = vim.split(path, '/')
+  local filename = table.remove(parents, #parents)
+  local remain = max_len - #filename
+  local parents_str = shorten_path(parents, remain)
+  return filename, parents_str
+end
+
+utils.devicon_for = (function()
+  local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
+  if has_devicons and not devicons.has_loaded() then
+    devicons.setup()
+  end
+  return function(filepath, opts)
+    opts = opts or {}
+    local conf = require('telescope.config').values
+    if not has_devicons or opts.disable_devicons or not filepath then
+      return ''
+    end
+
+    local basename = path_tail(filepath)
+    local icon, hl = devicons.get_icon(basename, file_extension(basename), { default = false })
+    if not icon then
+      icon, hl = devicons.get_icon(basename, nil, { default = true })
+      icon = icon or ' '
+    end
+    if conf.color_devicons then
+      return icon, hl
+    else
+      return icon, nil
+    end
+  end
+end)()
+
+return utils


### PR DESCRIPTION
- Display filename on the left, full path without filename on the right
- Skip intermediate nodes on the path if the path too long
- Screenshot:

![image](https://github.com/vhminh/better-telescope-builtins.nvim/assets/40837587/7bd45bc8-4369-4016-8aae-21abb439b037)
